### PR TITLE
Enable DevOps bits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,22 @@
 buildscript {
 	ext {
 		springBootVersion = '1.3.2.RELEASE'
+		gradleGitPropertiesVersion = '1.4.11'
 	}
 	repositories {
 		mavenCentral()
+		maven { url "https://plugins.gradle.org/m2/" }
 	}
 	dependencies {
-		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}") 
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+		classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
 	}
 }
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
-apply plugin: 'spring-boot' 
+apply plugin: 'spring-boot'
+apply plugin: "com.gorylenko.gradle-git-properties"
 
 jar {
 	baseName = 'springoneplatform-site'
@@ -25,9 +29,10 @@ repositories {
 	mavenCentral()
 }
 
-
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-thymeleaf')
+	compile('org.springframework.boot:spring-boot-starter-security')
+	compile('org.springframework.boot:spring-boot-actuator')
 	testCompile('org.springframework.boot:spring-boot-starter-test') 
 }
 

--- a/src/main/java/io/springoneplatform/SecurityConfiguration.java
+++ b/src/main/java/io/springoneplatform/SecurityConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.springoneplatform;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.stereotype.Component;
+
+/**
+ * The site is generally wide open, but in order to secure management bits ONLY,
+ * this policy is needed.
+ */
+@Component
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+			.authorizeRequests()
+
+				// Secure management endpoints
+				.antMatchers("/info").authenticated()
+
+				// But enable everything else
+				.antMatchers("/*").permitAll()
+
+				.and()
+			// Use a form login to access the secured bits
+			.formLogin()
+				.permitAll();
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+# Disable all actuator endpoints...
+endpoints.enabled=false
+
+# ...except /info
+endpoints.info.enabled=true
+
+security.user.name=admin
+security.user.password=springone


### PR DESCRIPTION
* Add Spring Boot actuator to power up /info management endpoint
* Disable ALL endpoints by default, but activate /info
* Use the git-gradle-properties plugin to serve up git-based metadata so we can see what version if deployed.
* Use Spring Security to protect /info but leave rest of site wide open.