### PR TITLE
URL Cleanup

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -11,13 +11,13 @@ curl_results=$(curl springoneplatform.cfapps.io)
 if [[ $curl_results == *springoneplatform.cfapps.io* ]]
 then
   cf push springoneplatform
-  read -p "Test http://springoneplatform.cfapps.io, then press [Enter] key to continue mapping springoneplatform.io route..."
+  read -p "Test https://springoneplatform.cfapps.io, then press [Enter] key to continue mapping springoneplatform.io route..."
   cf map-route springoneplatform springoneplatform.io
   cf unmap-route springoneplatform2 springoneplatform.io
   cf stop springoneplatform2
 else
   cf push springoneplatform2
-  read -p "Test http://springoneplatform2.cfapps.io, then press [Enter] key to continue mapping springoneplatform.io route..."
+  read -p "Test https://springoneplatform2.cfapps.io, then press [Enter] key to continue mapping springoneplatform.io route..."
   cf map-route springoneplatform2 springoneplatform.io
   cf unmap-route springoneplatform springoneplatform.io
   cf stop springoneplatform


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://springoneplatform.cfapps.io (404) migrated to:  
  https://springoneplatform.cfapps.io ([https](https://springoneplatform.cfapps.io) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://springoneplatform2.cfapps.io migrated to:  
  https://springoneplatform2.cfapps.io ([https](https://springoneplatform2.cfapps.io) result 200).